### PR TITLE
Set default EXPECTED_FAILURES_PREFIX to `expected-failures`

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,8 +102,8 @@ func getShifts(out io.Writer) int {
 
 	if expectedFailuresPrefix == "" {
 		io.WriteString(out, "Expected Failures prefix not provided\n")
-		io.WriteString(out, "using 'expected-failure as prefix of expected failure files by default'\n")
-		expectedFailuresPrefix = "expected-failure"
+		io.WriteString(out, "using 'expected-failures' as prefix of expected failure files by default\n")
+		expectedFailuresPrefix = "expected-failures"
 	}
 
 	files, err := ioutil.ReadDir(expectedFailuresDir)

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ go run main.go <command>
 
     - `FEATURES_PATH` Path where the Features files are
     - `EXPECTED_FAILURES_DIR` Path were expected failures files are
-    - `EXPECTED_FAILURES_PREFIX` Prefix of the expected failure files in expectged failures dir (defaults to `expected-failure`)
+    - `EXPECTED_FAILURES_PREFIX` Prefix of the expected failure files in expectged failures dir (defaults to `expected-failures`)
 
 - #### check-and
     Replace subsequent Given, Given steps with Given, And


### PR DESCRIPTION
fixes https://github.com/JankariTech/expected-failures-updater/issues/9

The default prefix of the expected failure file should be `expected-failures` but currently the app expects `expected-failure` so we need to pass `EXPECTED_FAILURES_PREFIX` but we can use the default value if we change the prefix expectations and this PR does so.